### PR TITLE
Work on Ruby 2, be more like Hash, and loosen type-checking on #update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ doc
 # jeweler generated
 pkg
 
+# byebug
+.byebug_history
+
 # Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
 #
 # * Create a file at ~/.gitignore
@@ -39,7 +42,8 @@ pkg
 #.\#*
 
 # For vim:
-#*.swp
+*.swp
+*.swo
 
 # For redcar:
 #.redcar

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,10 @@ source 'http://rubygems.org'
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
-  gem 'bundler', '~> 1.0.0'
-  gem 'jeweler', '~> 1.6.2'
-  gem 'rcov', '>= 0', :platform => :mri
+  gem 'bundler', '~> 1'
+  gem 'jeweler', '~> 1'
+  gem 'simplecov', '>= 0', :platform => :mri
   gem 'rdoc', '>= 0'
+  gem 'test-unit', '>= 3'
+  gem 'byebug', '>= 8'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,66 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    git (1.2.5)
-    jeweler (1.6.4)
+    addressable (2.4.0)
+    builder (3.2.2)
+    byebug (8.2.3)
+    docile (1.1.5)
+    faraday (0.8.11)
+      multipart-post (~> 1.2.0)
+    git (1.3.0)
+    github_api (0.10.1)
+      addressable
+      faraday (~> 0.8.1)
+      hashie (>= 1.2)
+      multi_json (~> 1.4)
+      nokogiri (~> 1.5.2)
+      oauth2
+    hashie (3.4.4)
+    highline (1.7.8)
+    jeweler (1.8.8)
+      builder
       bundler (~> 1.0)
       git (>= 1.2.5)
+      github_api (= 0.10.1)
+      highline (>= 1.6.15)
+      nokogiri (= 1.5.10)
       rake
-    rake (0.9.2)
-    rcov (0.9.9)
-    rdoc (3.8)
+      rdoc
+    json (1.8.3)
+    jwt (1.5.4)
+    multi_json (1.12.1)
+    multi_xml (0.5.5)
+    multipart-post (1.2.0)
+    nokogiri (1.5.10)
+    oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    power_assert (0.2.2)
+    rack (2.0.1)
+    rake (11.2.2)
+    rdoc (4.2.2)
+      json (~> 1.4)
+    simplecov (0.11.2)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    test-unit (3.0.8)
+      power_assert
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.0.0)
-  jeweler (~> 1.6.2)
-  rcov
+  bundler (~> 1)
+  byebug (>= 8)
+  jeweler (~> 1)
   rdoc
+  simplecov
+  test-unit (>= 3)
+
+BUNDLED WITH
+   1.11.2

--- a/README.rdoc
+++ b/README.rdoc
@@ -3,7 +3,7 @@
 Pure-ruby implementation of the rbtree gem, providing red-black trees.
 
 == Contributing to rbtree-pure
- 
+
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet
 * Check out the issue tracker to make sure someone already hasn't requested it and/or contributed it
 * Fork the project

--- a/lib/rbtree.rb
+++ b/lib/rbtree.rb
@@ -1,5 +1,5 @@
 # :nodoc: namespace
-class RBTree  
+class RBTree
 end
 
 require 'rbtree/node.rb'

--- a/lib/rbtree/guard_node.rb
+++ b/lib/rbtree/guard_node.rb
@@ -1,6 +1,6 @@
 # :nodoc: namespace
 class RBTree
-  
+
 # Node instance used as a guard.
 class GuardNode < Node
   def initialize
@@ -15,11 +15,11 @@ class GuardNode < Node
   def nil?
     true
   end
-  
+
   def to_a
     nil
   end
-  
+
   def inspect
     'RBTree::GuardNode'
   end

--- a/lib/rbtree/multi_rb_tree.rb
+++ b/lib/rbtree/multi_rb_tree.rb
@@ -4,17 +4,17 @@ class MultiRBTree < RBTree
     super(default, &default_proc)
     @size = 0
   end
-  
+
   def lower_bound(key)
     node = @tree.lower_bound(key)
     [node.key, node.value.first]
   end
-  
+
   def upper_bound(key)
     node = @tree.lower_bound(key)
     [node.key, node.value.last]
   end
-  
+
   def bound(lower_key, upper_key = nil)
     result = []
     bound_nodes lower_key, upper_key do |node|
@@ -42,14 +42,14 @@ class MultiRBTree < RBTree
     @default = other.default
     @cmp_proc = other.cmp_proc
     @size = other.size
-    
+
     unless other.instance_of? MultiRBTree
       # Wrap values in arrays to convert RBTree -> MultiRBTree.
       @tree.inorder do |node|
         node.value = [node.value]
       end
     end
-    
+
     self
   end
 end
@@ -61,25 +61,25 @@ class MultiRBTree
     node = @tree.minimum
     node.nil? ? default : [node.key, node.value.first]
   end
-  
+
   # The [key, value] for the largest key in the tree.
   def last
     node = @tree.maximum
     node.nil? ? default : [node.key, node.value.last]
   end
-  
+
   # Removes the largest key in the tree.
   def pop
-    return default if (node = @tree.maximum).nil? 
+    return default if (node = @tree.maximum).nil?
     value = node.value.pop
     @tree.delete node if node.value.empty?
     @size -= 1
     [node.key, value]
   end
-  
+
   # Removes the smallest key in the tree.
   def shift
-    return default if (node = @tree.minimum).nil? 
+    return default if (node = @tree.minimum).nil?
     value = node.value.shift
     @tree.delete node if node.value.empty?
     @size -= 1
@@ -94,7 +94,7 @@ class MultiRBTree
     node = tree.search key
     node ? node.value.first : default(key)
   end
-  
+
   # See Hash#[]=
   def []=(key, value)
     raise TypeError, 'cannot modify rbtree in iteration' if @lock_count > 0
@@ -104,10 +104,10 @@ class MultiRBTree
     @size += 1
     value
   end
-  
+
   # See Hash#size
   attr_reader :size
-  
+
   # See Hash#empty
   def empty?
     @tree.empty?
@@ -118,7 +118,7 @@ class MultiRBTree
     super
     @size = 0
   end
-  
+
   # See Hash#each
   def each
     if block_given?
@@ -132,7 +132,7 @@ class MultiRBTree
     end
   end
   alias :each_pair :each
-  
+
   # See Hash#reverse_each
   def reverse_each
     if block_given?
@@ -145,13 +145,13 @@ class MultiRBTree
       Enumerator.new self, :reverse_each
     end
   end
-  
+
   # See Hash#index
   def index(value)
     each { |k, v| return k if v.include? value }
     nil
   end
-  
+
   # See Hash#fetch
   def fetch(key, *default)
     if default.length > 1
@@ -160,7 +160,7 @@ class MultiRBTree
     if default.length == 1 && block_given?
       $stderr << "warning: block supersedes default value argument"
     end
-    
+
     node = tree.search key
     return node.value.first if node
     if block_given?
@@ -173,7 +173,7 @@ class MultiRBTree
       end
     end
   end
-  
+
   # See Hash#delete
   def delete(key)
     node = @tree.search key
@@ -185,7 +185,7 @@ class MultiRBTree
     @size -= 1
     value
   end
-  
+
   # See Hash#reject!
   def reject!
     if block_given?
@@ -205,7 +205,7 @@ class MultiRBTree
       Enumerator.new self, :each
     end
   end
-  
+
   # See Hash#reject
   def reject(&block)
     copy = self.dup
@@ -214,7 +214,7 @@ class MultiRBTree
     #       bug-for-bug
     # copy
   end
-  
+
   # See Hash#each_key.
   def each_key
     if block_given?
@@ -226,7 +226,7 @@ class MultiRBTree
     end
   end
 
-  
+
   # See Hash#each_value.
   def each_value
     if block_given?
@@ -237,13 +237,13 @@ class MultiRBTree
       Enumerator.new self, :each_value
     end
   end
-  
+
   # See Hash#merge!
   def merge!(other)
     unless other.instance_of? RBTree
       raise TypeError, "wrong argument type #{other.class} (expected RBTree)"
     end
-    
+
     if block_given?
       other.each do |key, value|
         if node = @tree.search(key)
@@ -258,19 +258,19 @@ class MultiRBTree
     self
   end
   alias :update :merge!
-  
+
   # See Hash#merge
   def merge(other)
     copy = self.dup
     copy.merge! other
     copy
   end
-  
+
   # A new Hash with the same contents and defaults as this RBTree instance.
   def to_hash
     raise TypeError, "can't convert MultiRBTree to Hash"
   end
-  
+
   # :nodoc:
   def inspect
     contents = map { |k, v|
@@ -281,7 +281,7 @@ class MultiRBTree
     default_inspect = default.equal?(self) ? '#<RBTree: ...>' : default.inspect
     "#<MultiRBTree: {#{contents}}, default=#{default_inspect}, cmp_proc=#{@cmp_proc.inspect}>"
   end
-  
+
   # :nodoc: custom pp output
   def pretty_print(q)
     q.group(1, "#<#{self.class.name}: ", '>') do
@@ -309,7 +309,7 @@ class MultiRBTree
       q.pp cmp_proc
     end
   end
-  
+
   # :nodoc: custom pp output
   def pretty_print_cycle(q)
     q.text '"#<MultiRBTree: ...>"'

--- a/lib/rbtree/node.rb
+++ b/lib/rbtree/node.rb
@@ -32,21 +32,21 @@ class Node
   def red?
     @color == :red
   end
-  
+
   # Returns an array of the node's [key, value].
   #
   # This method is used for nodes in a RBTree's tree.
   def to_a
     [@key, @value]
   end
-  
+
   # Returns an array of the node's [key, first value].
   #
   # This method is used for nodes in a MultiRBTree's tree.
   def to_single_a
     [@key, @value.first]
   end
-  
+
   def inspect
     <<ENDI
 <RBTree::Node (#{@color}) #{@key.inspect} -> #{@value.inspect}
@@ -55,5 +55,5 @@ class Node
 ENDI
   end
 end  # class RBTree::Node
-  
+
 end  # namespace RBTree

--- a/lib/rbtree/rb_tree.rb
+++ b/lib/rbtree/rb_tree.rb
@@ -275,7 +275,7 @@ class RBTree
 
   # See Hash#index
   def index(value)
-    each { |k, v| return k if value == v }
+    each { |k, v| return k if value.eql? v }
     nil
   end
 

--- a/lib/rbtree/rb_tree.rb
+++ b/lib/rbtree/rb_tree.rb
@@ -1,33 +1,33 @@
 # Sorted hash.
 class RBTree
   include Enumerable
-  
+
   # The red-black tree backing this store.
   attr_reader :tree
-  
+
   # The value returned when trying to read keys that don't exist in the tree.
   def default(key = nil)
     @default_proc ? @default_proc.call(tree, key) : @default
   end
-  
+
   # The value returned when trying to read keys that don't exist in the tree.
   def default=(new_default)
     @default_proc = nil
     @default = new_default
   end
-  
+
   # Block called when trying to read keys that don't exist in the tree.
   attr_reader :default_proc
-  
+
   # Block called when trying to read keys that don't exist in the tree.
   def default_proc=(new_proc)
     @default = nil
     @default_proc = new_proc
   end
-  
+
   # Block used to implement custom comparisons.
   attr_reader :cmp_proc
-  
+
   def initialize(default = nil, &default_proc)
     raise ArgumentError, "wrong number of arguments" if default && default_proc
     @default = default
@@ -42,7 +42,7 @@ class RBTree
     @tree = source.tree.dup
     @lock_count = 0
   end
-  
+
   def self.[](*key_values)
     if key_values.length == 1
       hash = key_values.first
@@ -60,18 +60,18 @@ class RBTree
       end
       return tree
     end
-    
+
     if key_values.length % 2 == 1
       raise ArgumentError, 'odd number of arguments for RBTree'
     end
-    
+
     tree = self.new
     0.upto(key_values.length / 2 - 1) do |i|
       tree[key_values[i * 2]] = key_values[i * 2 + 1]
     end
     tree
   end
-  
+
   # Rejects changes while this method's block is executed.
   def lock_changes
     begin
@@ -82,15 +82,15 @@ class RBTree
     end
   end
   private :lock_changes
-  
+
   def lower_bound(key)
     @tree.lower_bound(key).to_a
   end
-  
+
   def upper_bound(key)
     @tree.upper_bound(key).to_a
   end
-  
+
   def bound(lower_key, upper_key = nil)
     result = []
     bound_nodes lower_key, upper_key do |node|
@@ -103,7 +103,7 @@ class RBTree
     block_given? ? self : result
   end
 
-  # Internal version of bound that yields the corresponding nodes.  
+  # Internal version of bound that yields the corresponding nodes.
   def bound_nodes(lower_key, upper_key = nil)
     upper_key ||= lower_key
     node = @tree.lower_bound(lower_key)
@@ -125,14 +125,14 @@ class RBTree
       end
     end
   end
-  
+
   def to_rbtree
     self
   end
-  
+
   def readjust(*proc_arg, &new_cmp_proc)
     raise TypeError, 'cannot modify rbtree in iteration' if @lock_count > 0
-    
+
     if new_cmp_proc
       cmp_proc = new_cmp_proc
       unless proc_arg.empty?
@@ -140,21 +140,21 @@ class RBTree
       end
     else
       unless proc_arg.length <= 1
-        raise ArgumentError, "expected 1 arguments (given #{proc_arg.length})"        
+        raise ArgumentError, "expected 1 arguments (given #{proc_arg.length})"
       end
       unless proc_arg.first.respond_to?(:call) || proc_arg.first.nil?
         raise TypeError, "expected a proc argument"
       end
       cmp_proc = proc_arg.first
     end
-    
+
     lock_changes do
       if cmp_proc
         new_tree = RBTree::TreeCmp.new(&cmp_proc)
       else
         new_tree = RBTree::Tree.new
       end
-      
+
       @tree.inorder do |node|
         new_tree.insert new_tree.node(node.key, node.value)
       end
@@ -162,13 +162,13 @@ class RBTree
       @cmp_proc = cmp_proc
     end
   end
-  
+
   def replace(other)
     raise TypeError, 'cannot modify rbtree in iteration' if @lock_count > 0
     unless other.instance_of? RBTree
       raise TypeError, "expected RBTree, got #{other.class}"
     end
-    
+
     @tree = other.tree.dup
     @default_proc = other.default_proc
     @default = other.default
@@ -184,23 +184,23 @@ class RBTree
     node = @tree.minimum
     node.nil? ? default : node.to_a
   end
-  
+
   # The [key, value] for the largest key in the tree.
   def last
     node = @tree.maximum
     node.nil? ? default : node.to_a
   end
-  
+
   # Removes the largest key in the tree.
   def pop
-    return default if (node = @tree.maximum).nil? 
+    return default if (node = @tree.maximum).nil?
     @tree.delete node
     node.to_a
   end
-  
+
   # Removes the smallest key in the tree.
   def shift
-    return default if (node = @tree.minimum).nil? 
+    return default if (node = @tree.minimum).nil?
     @tree.delete node
     node.to_a
   end
@@ -213,7 +213,7 @@ class RBTree
     node = tree.search key
     node ? node.value : default(key)
   end
-  
+
   # See Hash#[]=
   def []=(key, value)
     raise TypeError, 'cannot modify rbtree in iteration' if @lock_count > 0
@@ -221,34 +221,34 @@ class RBTree
     key = key.clone.freeze if key.kind_of? String
     @tree.insert(@tree.node(key, value)).value = value
   end
-  
+
   # See Hash#size
   def size
     @tree.size
   end
-  
+
   # See Hash#empty
   def empty?
     @tree.empty?
   end
 
-  # See Hash#clear  
+  # See Hash#clear
   def clear
     @tree = RBTree::Tree.new
   end
-  
+
   # See Hash#==
   def ==(other)
     return false unless other.kind_of?(RBTree)
     return false unless other.size == self.size
     return false unless other.cmp_proc == @cmp_proc
-    
+
     ary = self.to_a
     other_ary = other.to_a
     ary.each_with_index { |v, i| return false unless other_ary[i] == v }
     true
   end
-  
+
   # See Hash#each
   def each
     if block_given?
@@ -260,7 +260,7 @@ class RBTree
     end
   end
   alias :each_pair :each
-  
+
   # See Hash#reverse_each
   def reverse_each
     if block_given?
@@ -271,14 +271,14 @@ class RBTree
       Enumerator.new self, :reverse_each
     end
   end
-  
-  
+
+
   # See Hash#index
   def index(value)
     each { |k, v| return k if value == v }
     nil
   end
-  
+
   # See Hash#fetch
   def fetch(key, *default)
     if default.length > 1
@@ -287,7 +287,7 @@ class RBTree
     if default.length == 1 && block_given?
       $stderr << "warning: block supersedes default value argument"
     end
-    
+
     node = tree.search key
     return node.value if node
     if block_given?
@@ -300,7 +300,7 @@ class RBTree
       end
     end
   end
-  
+
   # See Hash#delete
   def delete(key)
     node = @tree.search key
@@ -310,13 +310,13 @@ class RBTree
     @tree.delete node
     node.value
   end
-  
+
   # See Hash#delete_if
   def delete_if(&block)
     reject!(&block)
     self
   end
-  
+
   # See Hash#reject!
   def reject!
     if block_given?
@@ -332,7 +332,7 @@ class RBTree
       Enumerator.new self, :each
     end
   end
-  
+
   # See Hash#reject
   def reject(&block)
     copy = self.dup
@@ -341,7 +341,7 @@ class RBTree
     #       bug-for-bug
     # copy
   end
-  
+
   # See Hash#each_key.
   def each_key
     if block_given?
@@ -363,26 +363,26 @@ class RBTree
       Enumerator.new self, :each_value
     end
   end
-  
+
   # See Hash#keys.
   def keys
     result = Array.new
     each_key { |key| result << key }
     result
   end
-  
+
   # See Hash#values.
   def values
     result = Array.new
     each_value { |value| result << value }
     result
   end
-  
+
   # See Hash#has_key?
   def has_key?(key)
     !!@tree.search(key)
   end
-  
+
   # See Hash#has_value?
   def has_value?(value)
     lock_changes do
@@ -390,25 +390,25 @@ class RBTree
     end
     false
   end
-  
+
   # See Hash#invert
   def invert
     tree = self.class.new
     each { |key, value| tree[value] = key }
     tree
   end
-  
+
   # See Hash#values_at
   def values_at(*keys)
     keys.map { |key| self[key] }
   end
-  
+
   # See Hash#merge!
   def merge!(other)
     unless other.instance_of? RBTree
       raise TypeError, "wrong argument type #{other.class} (expected RBTree)"
     end
-    
+
     if block_given?
       other.each do |key, value|
         if node = @tree.search(key)
@@ -423,19 +423,19 @@ class RBTree
     self
   end
   alias :update :merge!
-  
+
   # See Hash#merge
   def merge(other)
     copy = self.dup
     copy.merge! other
     copy
   end
-  
+
   # :nodoc:
   def to_s
     to_a.to_s
   end
-  
+
   # A new Hash with the same contents and defaults as this RBTree instance.
   def to_hash
     if @default_proc && !Hash.method_defined?(:default_proc=)
@@ -453,7 +453,7 @@ class RBTree
     end
     hash
   end
-  
+
   # :nodoc:
   def inspect
     contents = map { |k, v|
@@ -464,7 +464,7 @@ class RBTree
     default_inspect = default.equal?(self) ? '#<RBTree: ...>' : default.inspect
     "#<RBTree: {#{contents}}, default=#{default_inspect}, cmp_proc=#{@cmp_proc.inspect}>"
   end
-  
+
   def pretty_print(q)
     q.group(1, '#<RBTree: ', '>') do
       q.pp_hash self
@@ -478,7 +478,7 @@ class RBTree
       q.pp cmp_proc
     end
   end
-  
+
   def pretty_print_cycle(q)
     q.text '"#<RBTree: ...>"'
   end

--- a/lib/rbtree/rb_tree.rb
+++ b/lib/rbtree/rb_tree.rb
@@ -440,7 +440,7 @@ class RBTree
   def to_hash
     if @default_proc && !Hash.method_defined?(:default_proc=)
       # Slow path for default block and Ruby 1.8.7
-      hash = Hash.new &@default_proc
+      hash = Hash.new(&@default_proc)
       each { |key, value| hash[key] = value }
       return hash
     end

--- a/lib/rbtree/rb_tree.rb
+++ b/lib/rbtree/rb_tree.rb
@@ -405,11 +405,11 @@ class RBTree
 
   # See Hash#merge!
   def merge!(other)
-    unless other.instance_of? RBTree
-      raise TypeError, "wrong argument type #{other.class} (expected RBTree)"
-    end
-
     if block_given?
+      unless other.kind_of? RBTree
+        raise TypeError, "wrong argument type #{other.class} (expected RBTree)"
+      end
+
       other.each do |key, value|
         if node = @tree.search(key)
           node.value = yield key, node.value, value
@@ -418,6 +418,9 @@ class RBTree
         end
       end
     else
+      unless other.respond_to?(:each)
+        raise TypeError, "wrong argument type #{other.class} (expected Enumerable)"
+      end
       other.each { |key, value| self[key] = value }
     end
     self

--- a/lib/rbtree/tree.rb
+++ b/lib/rbtree/tree.rb
@@ -8,10 +8,10 @@ class RBTree
 class Tree
   # The tree's root node.
   attr_reader :root
-  
+
   # The number of nodes in the tree.
   attr_reader :size
-  
+
   # The tree's guard node.
   attr_reader :guard
   protected :guard
@@ -22,14 +22,14 @@ class Tree
     @size = 0
     @root = @guard
   end
-  
+
   # Makes a deep copy of the source's tree, but uses the original keys & values.
   def initialize_copy(source)
     super
     @guard = GuardNode.new
     @root = clone_tree source.root, source.guard
   end
-  
+
   # Produces a copy of a subtree.
   #
   # Arg:
@@ -151,7 +151,7 @@ class Tree
   # The node with the lowest key that is higher than the given node's key.
   def successor(x)
     return minimum(x.right) unless x.right.nil?
-    
+
     y = x.parent
     while !y.nil? && x == y.right
       x = y
@@ -163,7 +163,7 @@ class Tree
   # The node with the highest key that is lower than the given node's key.
   def predecessor(x)
     return maximum(x.left) unless x.left.nil?
-    
+
     y = x.parent
     while !y.nil? && x == y.left
       x = y
@@ -198,10 +198,10 @@ class Tree
     end
     nil
   end
-  
+
   # Returns the node with the smallest key that is >= the given key.
   #
-  # Returns nil if called on an empty tree or the guard node.  
+  # Returns nil if called on an empty tree or the guard node.
   def lower_bound(key, node = root)
     return nil if node.nil?
     loop do
@@ -217,10 +217,10 @@ class Tree
       node = next_node
     end
   end
-  
+
   # Returns a node with the largest key that is <= then given key.
   #
-  # Returns nil if called on an empty tree or the guard node.  
+  # Returns nil if called on an empty tree or the guard node.
   def upper_bound(key, node = root)
     return nil if node.nil?
     loop do

--- a/lib/rbtree/tree.rb
+++ b/lib/rbtree/tree.rb
@@ -193,8 +193,10 @@ class Tree
   # Returns a node containing the given key or nil if no node contains the key.
   def search(key, node = root)
     until node.nil?
-      return node if node.key == key
-      node = ((key <=> node.key) < 0) ? node.left : node.right
+      comparison = node.key <=> key
+      return node if comparison == 0
+      raise "#{key.inspect} and #{node.key.inspect} are not comparable" if comparison.nil?
+      node = (comparison > 0) ? node.left : node.right
     end
     nil
   end
@@ -205,9 +207,9 @@ class Tree
   def lower_bound(key, node = root)
     return nil if node.nil?
     loop do
-      cmp = key <=> node.key
+      cmp = node.key <=> key
       return node if cmp == 0
-      if cmp < 0
+      if cmp > 0
         next_node = node.left
         return node if next_node.nil?
       else
@@ -224,9 +226,9 @@ class Tree
   def upper_bound(key, node = root)
     return nil if node.nil?
     loop do
-      cmp = key <=> node.key
+      cmp = node.key <=> key
       return node if cmp == 0
-      if cmp < 0
+      if cmp > 0
         next_node = node.left
         return predecessor(node) if next_node.nil?
       else

--- a/lib/rbtree/tree_cmp.rb
+++ b/lib/rbtree/tree_cmp.rb
@@ -16,7 +16,7 @@ class TreeCmp < Tree
   # Returns a node containing the given key or nil if no node contains the key.
   def search(key, node = root)
     until node.nil?
-      return node if node.key == key
+      return node if node.key.eql?(key)
       node = @cmp_proc.call(key, node.key) < 0 ? node.left : node.right
     end
     nil

--- a/lib/rbtree/tree_cmp.rb
+++ b/lib/rbtree/tree_cmp.rb
@@ -16,7 +16,7 @@ class TreeCmp < Tree
   # Returns a node containing the given key or nil if no node contains the key.
   def search(key, node = root)
     until node.nil?
-      return node if node.key.eql?(key)
+      return node if key.eql?(node.key)
       node = @cmp_proc.call(key, node.key) < 0 ? node.left : node.right
     end
     nil

--- a/lib/rbtree/tree_cmp.rb
+++ b/lib/rbtree/tree_cmp.rb
@@ -12,7 +12,7 @@ class TreeCmp < Tree
     @size = 0
     @root = @guard
   end
-  
+
   # Returns a node containing the given key or nil if no node contains the key.
   def search(key, node = root)
     until node.nil?
@@ -21,10 +21,10 @@ class TreeCmp < Tree
     end
     nil
   end
-  
+
   # Returns the node with the smallest key that is >= the given key.
   #
-  # Returns nil if called on an empty tree or the guard node.  
+  # Returns nil if called on an empty tree or the guard node.
   def lower_bound(key, node = root)
     return nil if node.nil?
     loop do
@@ -40,10 +40,10 @@ class TreeCmp < Tree
       node = next_node
     end
   end
-  
+
   # Returns a node with the largest key that is <= then given key.
   #
-  # Returns nil if called on an empty tree or the guard node.  
+  # Returns nil if called on an empty tree or the guard node.
   def upper_bound(key, node = root)
     return nil if node.nil?
     loop do

--- a/test/cjh_test.rb
+++ b/test/cjh_test.rb
@@ -1,0 +1,19 @@
+require 'helper'
+
+require 'byebug'
+
+class RBTreeCJHTest < Test::Unit::TestCase
+  def setup
+    @rbtree = RBTree[*%w(b B d D a A c C)]
+  end
+
+  def test_hash_merge
+    rbtree = RBTree.new
+    rbtree["e"] = "E"
+
+    ret = @rbtree.merge({'e' => 'E'})
+    assert_equal(RBTree[*%w(a A b B c C d D e E)], ret)
+
+    assert_equal(4, @rbtree.size)
+  end
+end

--- a/test/cjh_test.rb
+++ b/test/cjh_test.rb
@@ -3,8 +3,24 @@ require 'helper'
 require 'byebug'
 
 class RBTreeCJHTest < Test::Unit::TestCase
+  class CIString < String
+    def eql? other
+      (''+downcase).eql? other.downcase
+    end
+
+    def <=>(other)
+      # downcase yields a CIString.
+      ''+downcase <=> other.downcase
+    end
+  end
+
   def setup
-    @rbtree = RBTree[*%w(b B d D a A c C)]
+    @rbtree = RBTree[*%w(b B d D a A c C).map{|s| CIString.new(s)}]
+  end
+
+  def test_eql
+    assert_equal('B', @rbtree['b'])
+    assert_equal('B', @rbtree['B'])
   end
 
   def test_hash_merge

--- a/test/multi_rbtree_test.rb
+++ b/test/multi_rbtree_test.rb
@@ -105,7 +105,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
   def test_update
     assert_equal(MultiRBTree[*%w(a A b B)],
                  MultiRBTree[*%w(a A)].update(RBTree[*%w(b B)]))
-    assert_raises(TypeError) {
+    assert_nothing_raised {
       RBTree[*%w(a A)].update(MultiRBTree[*%w(b B)])
     }
   end

--- a/test/multi_rbtree_test.rb
+++ b/test/multi_rbtree_test.rb
@@ -3,7 +3,7 @@ require 'helper'
 # The code below is lifted from the rbtree gem. Here is its LICENSE.
 #
 # Copyright (c) 2002-2004, 2007, 2009-2010 OZAWA Takuma
-# 
+#
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
 # files (the "Software"), to deal in the Software without
@@ -12,10 +12,10 @@ require 'helper'
 # copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following
 # conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 # OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -32,7 +32,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
 
   def test_create
     assert_equal(%w(a A b B b C b D c C), @rbtree.to_a.flatten)
-    
+
     assert_equal(MultiRBTree[*%w(a A)], MultiRBTree[RBTree[*%w(a A)]])
     assert_raises(TypeError) {
       RBTree[MultiRBTree[*%w(a A)]]
@@ -53,7 +53,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
     @rbtree.clear
     assert_equal(true, @rbtree.empty?)
   end
-  
+
   def test_to_a
     assert_equal([%w(a A), %w(b B), %w(b C), %w(b D), %w(c C)],
                  @rbtree.to_a)
@@ -67,7 +67,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
       assert_equal(expected, @rbtree.to_s)
     end
   end
-  
+
   def test_to_hash
     assert_raises(TypeError) {
       @rbtree.to_hash
@@ -93,7 +93,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
     assert_equal(true, RBTree[*%w(a A)] == MultiRBTree[*%w(a A)])
     assert_equal(true, MultiRBTree[*%w(a A)] == RBTree[*%w(a A)])
   end
-  
+
   def test_replace
     assert_equal(RBTree[*%w(a A)],
                  MultiRBTree[*%w(a A)].replace(RBTree[*%w(a A)]))
@@ -113,7 +113,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
   def test_clone
     assert_equal(@rbtree, @rbtree.clone)
   end
-  
+
   def test_each
     ret = []
     @rbtree.each {|k, v|
@@ -150,7 +150,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
     @rbtree.readjust {|a, b| b <=> a }
     assert_equal(%w(c C b B b C b D a A), @rbtree.to_a.flatten)
   end
-  
+
   def test_marshal
     assert_equal(@rbtree, Marshal.load(Marshal.dump(@rbtree)))
   end
@@ -166,7 +166,7 @@ class MultiRBTreeTest < Test::Unit::TestCase
   def test_bound
     assert_equal(%w(b B b C b D), @rbtree.bound("b").flatten)
   end
-  
+
   def test_first
     assert_equal(%w(a A), @rbtree.first)
   end

--- a/test/rbtree_test.rb
+++ b/test/rbtree_test.rb
@@ -3,7 +3,7 @@ require 'helper'
 # The code below is lifted from the rbtree gem. Here is its LICENSE.
 #
 # Copyright (c) 2002-2004, 2007, 2009-2010 OZAWA Takuma
-# 
+#
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
 # files (the "Software"), to deal in the Software without
@@ -12,10 +12,10 @@ require 'helper'
 # copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following
 # conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 # OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -24,12 +24,12 @@ require 'helper'
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
- 
+
 class RBTreeTest < Test::Unit::TestCase
   def setup
     @rbtree = RBTree[*%w(b B d D a A c C)]
   end
-  
+
   def test_new
     assert_nothing_raised {
       RBTree.new
@@ -39,13 +39,13 @@ class RBTreeTest < Test::Unit::TestCase
     assert_raises(ArgumentError) { RBTree.new("a") {} }
     assert_raises(ArgumentError) { RBTree.new("a", "a") }
   end
-  
+
   def test_aref
     assert_equal("A", @rbtree["a"])
     assert_equal("B", @rbtree["b"])
     assert_equal("C", @rbtree["c"])
     assert_equal("D", @rbtree["d"])
-    
+
     assert_equal(nil, @rbtree["e"])
     @rbtree.default = "E"
     assert_equal("E", @rbtree["e"])
@@ -54,71 +54,71 @@ class RBTreeTest < Test::Unit::TestCase
   def test_size
     assert_equal(4, @rbtree.size)
   end
-  
+
   def test_create
     rbtree = RBTree[]
     assert_equal(0, rbtree.size)
-    
+
     rbtree = RBTree[@rbtree]
     assert_equal(4, rbtree.size)
     assert_equal("A", @rbtree["a"])
     assert_equal("B", @rbtree["b"])
     assert_equal("C", @rbtree["c"])
     assert_equal("D", @rbtree["d"])
-    
+
     rbtree = RBTree[RBTree.new("e")]
     assert_equal(nil, rbtree.default)
     rbtree = RBTree[RBTree.new { "e" }]
     assert_equal(nil, rbtree.default_proc)
     @rbtree.readjust {|a,b| b <=> a }
     assert_equal(nil, RBTree[@rbtree].cmp_proc)
-    
+
     assert_raises(ArgumentError) { RBTree["e"] }
-    
+
     rbtree = RBTree[Hash[*%w(b B d D a A c C)]]
     assert_equal(4, rbtree.size)
     assert_equal("A", rbtree["a"])
     assert_equal("B", rbtree["b"])
     assert_equal("C", rbtree["c"])
     assert_equal("D", rbtree["d"])
-    
+
     rbtree = RBTree[[%w(a A), %w(b B), %w(c C), %w(d D)]];
     assert_equal(4, rbtree.size)
     assert_equal("A", rbtree["a"])
     assert_equal("B", rbtree["b"])
     assert_equal("C", rbtree["c"])
     assert_equal("D", rbtree["d"])
-    
+
     rbtree = RBTree[[["a"]]]
     assert_equal(1, rbtree.size)
     assert_equal(nil, rbtree["a"])
   end
-  
+
   def test_clear
     @rbtree.clear
     assert_equal(0, @rbtree.size)
   end
-  
+
   def test_aset
     @rbtree["e"] = "E"
     assert_equal(5, @rbtree.size)
     assert_equal("E", @rbtree["e"])
-    
+
     @rbtree["c"] = "E"
     assert_equal(5, @rbtree.size)
     assert_equal("E", @rbtree["c"])
-    
+
     assert_raises(ArgumentError) { @rbtree[100] = 100 }
     assert_equal(5, @rbtree.size)
-    
-    
+
+
     key = "f"
     @rbtree[key] = "F"
     cloned_key = @rbtree.last[0]
     assert_equal("f", cloned_key)
     assert_not_same(key, cloned_key)
     assert_equal(true, cloned_key.frozen?)
-    
+
     @rbtree["f"] = "F"
     assert_same(cloned_key, @rbtree.last[0])
 
@@ -128,7 +128,7 @@ class RBTreeTest < Test::Unit::TestCase
     assert_same(key, rbtree.first[0])
     assert_equal(false, key.frozen?)
   end
-  
+
   def test_clone
     clone = @rbtree.clone
     assert_equal(4, @rbtree.size)
@@ -136,53 +136,53 @@ class RBTreeTest < Test::Unit::TestCase
     assert_equal("B", @rbtree["b"])
     assert_equal("C", @rbtree["c"])
     assert_equal("D", @rbtree["d"])
-    
+
     rbtree = RBTree.new("e")
     clone = rbtree.clone
     assert_equal("e", clone.default)
-    
+
     rbtree = RBTree.new { "e" }
     clone = rbtree.clone
     assert_equal("e", clone.default(nil))
-    
+
     rbtree = RBTree.new
     rbtree.readjust {|a, b| a <=> b }
     clone = rbtree.clone
     assert_equal(rbtree.cmp_proc, clone.cmp_proc)
   end
-  
+
   def test_default
     assert_equal(nil, @rbtree.default)
-    
+
     rbtree = RBTree.new("e")
     assert_equal("e", rbtree.default)
     assert_equal("e", rbtree.default("f"))
     assert_raises(ArgumentError) { rbtree.default("e", "f") }
-    
+
     rbtree = RBTree.new {|tree, key| @rbtree[key || "c"] }
     assert_equal("C", rbtree.default(nil))
     assert_equal("B", rbtree.default("b"))
   end
-  
+
   def test_set_default
     rbtree = RBTree.new { "e" }
     rbtree.default = "f"
     assert_equal("f", rbtree.default)
   end
-  
+
   def test_default_proc
     rbtree = RBTree.new("e")
     assert_equal(nil, rbtree.default_proc)
-    
+
     rbtree = RBTree.new { "e" }
     assert_equal("e", rbtree.default_proc.call)
   end
-  
+
   def test_equal
     assert_equal(RBTree.new, RBTree.new)
     assert_equal(@rbtree, @rbtree)
     assert_not_equal(@rbtree, RBTree.new)
-    
+
     rbtree = RBTree[*%w(b B d D a A c C)]
     assert_equal(@rbtree, rbtree)
     rbtree["d"] = "A"
@@ -192,17 +192,17 @@ class RBTreeTest < Test::Unit::TestCase
     assert_not_equal(@rbtree, rbtree)
     @rbtree["e"] = "E"
     assert_equal(@rbtree, rbtree)
-    
+
     rbtree.default = "e"
     assert_equal(@rbtree, rbtree)
     @rbtree.default = "f"
     assert_equal(@rbtree, rbtree)
-    
+
     a = RBTree.new("e")
     b = RBTree.new { "f" }
     assert_equal(a, b)
     assert_equal(b, b.clone)
-    
+
     a = RBTree.new
     b = RBTree.new
     a.readjust {|x, y| x <=> y }
@@ -210,18 +210,18 @@ class RBTreeTest < Test::Unit::TestCase
     b.readjust(a.cmp_proc)
     assert_equal(a, b)
   end
-  
+
   def test_fetch
     assert_equal("A", @rbtree.fetch("a"))
     assert_equal("B", @rbtree.fetch("b"))
     assert_equal("C", @rbtree.fetch("c"))
     assert_equal("D", @rbtree.fetch("d"))
-    
+
     assert_raises(IndexError) { @rbtree.fetch("e") }
-    
+
     assert_equal("E", @rbtree.fetch("e", "E"))
     assert_equal("E", @rbtree.fetch("e") { "E" })
-    
+
     class << (stderr = "")
       alias write <<
     end
@@ -232,7 +232,7 @@ class RBTreeTest < Test::Unit::TestCase
       $stderr, stderr, $VERBOSE, verbose = stderr, $stderr, false, $VERBOSE
     end
     assert_match(/warning: block supersedes default value argument/, stderr)
-    
+
     assert_raises(ArgumentError) { @rbtree.fetch }
     assert_raises(ArgumentError) { @rbtree.fetch("e", "E", "E") }
   end
@@ -247,17 +247,17 @@ class RBTreeTest < Test::Unit::TestCase
     @rbtree.clear
     assert_equal(true, @rbtree.empty?)
   end
-  
+
   def test_each
     ret = []
     @rbtree.each {|key, val| ret << key << val }
     assert_equal(%w(a A b B c C d D), ret)
-    
+
     assert_raises(TypeError) {
       @rbtree.each { @rbtree["e"] = "E" }
     }
     assert_equal(4, @rbtree.size)
-    
+
     @rbtree.each {
       @rbtree.each {}
       assert_raises(TypeError) {
@@ -266,13 +266,13 @@ class RBTreeTest < Test::Unit::TestCase
       break
     }
     assert_equal(4, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.each
       assert_equal(%w(a A b B c C d D), enumerator.map.flatten)
     end
   end
-  
+
   def test_each_pair
     ret = []
     @rbtree.each_pair {|key, val| ret << key << val }
@@ -291,13 +291,13 @@ class RBTreeTest < Test::Unit::TestCase
       break
     }
     assert_equal(4, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.each_pair
       assert_equal(%w(a A b B c C d D), enumerator.map.flatten)
     end
   end
-  
+
   def test_each_key
     ret = []
     @rbtree.each_key {|key| ret.push(key) }
@@ -316,13 +316,13 @@ class RBTreeTest < Test::Unit::TestCase
       break
     }
     assert_equal(4, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.each_key
       assert_equal(%w(a b c d), enumerator.map.flatten)
     end
   end
-  
+
   def test_each_value
     ret = []
     @rbtree.each_value {|val| ret.push(val) }
@@ -341,7 +341,7 @@ class RBTreeTest < Test::Unit::TestCase
       break
     }
     assert_equal(4, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.each_value
       assert_equal(%w(A B C D), enumerator.map.flatten)
@@ -353,52 +353,52 @@ class RBTreeTest < Test::Unit::TestCase
     assert_equal(3, @rbtree.size)
     assert_equal(["a", "A"], ret)
     assert_equal(nil, @rbtree["a"])
-    
+
     3.times { @rbtree.shift }
     assert_equal(0, @rbtree.size)
     assert_equal(nil, @rbtree.shift)
     @rbtree.default = "e"
     assert_equal("e", @rbtree.shift)
-    
+
     rbtree = RBTree.new { "e" }
     assert_equal("e", rbtree.shift)
   end
-  
+
   def test_pop
     ret = @rbtree.pop
     assert_equal(3, @rbtree.size)
     assert_equal(["d", "D"], ret)
     assert_equal(nil, @rbtree["d"])
-    
+
     3.times { @rbtree.pop }
     assert_equal(0, @rbtree.size)
     assert_equal(nil, @rbtree.pop)
     @rbtree.default = "e"
     assert_equal("e", @rbtree.pop)
-    
+
     rbtree = RBTree.new { "e" }
     assert_equal("e", rbtree.pop)
   end
-  
+
   def test_delete
     ret = @rbtree.delete("c")
     assert_equal("C", ret)
     assert_equal(3, @rbtree.size)
     assert_equal(nil, @rbtree["c"])
-    
+
     assert_equal(nil, @rbtree.delete("e"))
     assert_equal("E", @rbtree.delete("e") { "E" })
   end
-  
+
   def test_delete_if
     @rbtree.delete_if {|key, val| val == "A" || val == "B" }
     assert_equal(RBTree[*%w(c C d D)], @rbtree)
-    
+
     assert_raises(ArgumentError) {
       @rbtree.delete_if {|key, val| key == "c" or raise ArgumentError }
     }
     assert_equal(2, @rbtree.size)
-    
+
     assert_raises(TypeError) {
       @rbtree.delete_if { @rbtree["e"] = "E" }
     }
@@ -414,7 +414,7 @@ class RBTreeTest < Test::Unit::TestCase
       true
     }
     assert_equal(0, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       rbtree = RBTree[*%w(b B d D a A c C)]
       enumerator = rbtree.delete_if
@@ -426,38 +426,38 @@ class RBTreeTest < Test::Unit::TestCase
     ret = @rbtree.reject! { false }
     assert_equal(nil, ret)
     assert_equal(4, @rbtree.size)
-    
+
     ret = @rbtree.reject! {|key, val| val == "A" || val == "B" }
     assert_same(@rbtree, ret)
     assert_equal(RBTree[*%w(c C d D)], ret)
-    
+
     if defined?(Enumerable::Enumerator)
       rbtree = RBTree[*%w(b B d D a A c C)]
       enumerator = rbtree.reject!
       assert_equal([true, true, false, false], enumerator.map {|key, val| val == "A" || val == "B" })
     end
   end
-  
+
   def test_reject
     ret = @rbtree.reject { false }
     assert_equal(nil, ret)
     assert_equal(4, @rbtree.size)
-    
+
     ret = @rbtree.reject {|key, val| val == "A" || val == "B" }
     assert_equal(RBTree[*%w(c C d D)], ret)
     assert_equal(4, @rbtree.size)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.reject
       assert_equal([true, true, false, false], enumerator.map {|key, val| val == "A" || val == "B" })
     end
   end
-  
+
   def test_select
     ret = @rbtree.select {|key, val| val == "A" || val == "B" }
     assert_equal(%w(a A b B), ret.flatten)
     assert_raises(ArgumentError) { @rbtree.select("c") }
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.select
       assert_equal([true, true, false, false], enumerator.map {|key, val| val == "A" || val == "B"})
@@ -468,40 +468,40 @@ class RBTreeTest < Test::Unit::TestCase
     ret = @rbtree.values_at("d", "a", "e")
     assert_equal(["D", "A", nil], ret)
   end
-  
+
   def test_invert
     assert_equal(RBTree[*%w(A a B b C c D d)], @rbtree.invert)
   end
-  
+
   def test_update
     rbtree = RBTree.new
     rbtree["e"] = "E"
     @rbtree.update(rbtree)
     assert_equal(RBTree[*%w(a A b B c C d D e E)], @rbtree)
-    
+
     @rbtree.clear
     @rbtree["d"] = "A"
     rbtree.clear
     rbtree["d"] = "B"
-    
+
     @rbtree.update(rbtree) {|key, val1, val2|
       val1 + val2 if key == "d"
     }
     assert_equal(RBTree[*%w(d AB)], @rbtree)
-    
+
     assert_raises(TypeError) { @rbtree.update("e") }
   end
-  
+
   def test_merge
     rbtree = RBTree.new
     rbtree["e"] = "E"
-    
+
     ret = @rbtree.merge(rbtree)
     assert_equal(RBTree[*%w(a A b B c C d D e E)], ret)
-    
+
     assert_equal(4, @rbtree.size)
   end
-  
+
   def test_has_key
     assert_equal(true,  @rbtree.has_key?("a"))
     assert_equal(true,  @rbtree.has_key?("b"))
@@ -509,7 +509,7 @@ class RBTreeTest < Test::Unit::TestCase
     assert_equal(true,  @rbtree.has_key?("d"))
     assert_equal(false, @rbtree.has_key?("e"))
   end
-  
+
   def test_has_value
     assert_equal(true,  @rbtree.has_value?("A"))
     assert_equal(true,  @rbtree.has_value?("B"))
@@ -536,7 +536,7 @@ class RBTreeTest < Test::Unit::TestCase
     else
       expected = "[[\"a\", \"A\"], [\"b\", \"B\"], [\"c\", \"C\"], [\"d\", \"D\"]]"
       assert_equal(expected, @rbtree.to_s)
-      
+
       rbtree = RBTree.new
       rbtree[rbtree] = rbtree
       rbtree.default = rbtree
@@ -544,7 +544,7 @@ class RBTreeTest < Test::Unit::TestCase
       assert_equal(expected, rbtree.to_s)
     end
   end
-  
+
   def test_to_hash
     @rbtree.default = "e"
     hash = @rbtree.to_hash
@@ -563,19 +563,19 @@ class RBTreeTest < Test::Unit::TestCase
   def test_to_rbtree
     assert_same(@rbtree, @rbtree.to_rbtree)
   end
-  
+
   def test_inspect
     @rbtree.default = "e"
     @rbtree.readjust {|a, b| a <=> b}
     re = /#<RBTree: (\{.*\}), default=(.*), cmp_proc=(.*)>/
-    
+
     assert_match(re, @rbtree.inspect)
     match = re.match(@rbtree.inspect)
     tree, default, cmp_proc = match.to_a[1..-1]
     assert_equal(%({"a"=>"A", "b"=>"B", "c"=>"C", "d"=>"D"}), tree)
     assert_equal(%("e"), default)
     assert_match(/#<Proc:\w+(@#{__FILE__}:\d+)?>/o, cmp_proc)
-    
+
     rbtree = RBTree.new
     assert_match(re, rbtree.inspect)
     match = re.match(rbtree.inspect)
@@ -583,7 +583,7 @@ class RBTreeTest < Test::Unit::TestCase
     assert_equal("{}", tree)
     assert_equal("nil", default)
     assert_equal("nil", cmp_proc)
-    
+
     rbtree = RBTree.new
     rbtree[rbtree] = rbtree
     rbtree.default = rbtree
@@ -593,21 +593,21 @@ class RBTreeTest < Test::Unit::TestCase
     assert_equal("#<RBTree: ...>", default)
     assert_equal("nil", cmp_proc)
   end
-  
+
   def test_lower_bound
     rbtree = RBTree[*%w(a A c C e E)]
     assert_equal(["c", "C"], rbtree.lower_bound("c"))
     assert_equal(["c", "C"], rbtree.lower_bound("b"))
     assert_equal(nil, rbtree.lower_bound("f"))
   end
-  
+
   def test_upper_bound
     rbtree = RBTree[*%w(a A c C e E)]
     assert_equal(["c", "C"], rbtree.upper_bound("c"))
     assert_equal(["c", "C"], rbtree.upper_bound("d"))
     assert_equal(nil, rbtree.upper_bound("Z"))
   end
-  
+
   def test_bound
     rbtree = RBTree[*%w(a A c C e E)]
     assert_equal(%w(a A c C), rbtree.bound("a", "c").flatten)
@@ -619,21 +619,21 @@ class RBTreeTest < Test::Unit::TestCase
     assert_equal([], rbtree.bound("f", "g"))
     assert_equal([], rbtree.bound("f", "Z"))
   end
-  
+
   def test_bound_block
     ret = []
     @rbtree.bound("b", "c") {|key, val|
       ret.push(key)
     }
     assert_equal(%w(b c), ret)
-    
+
     assert_raises(TypeError) {
       @rbtree.bound("a", "d") {
         @rbtree["e"] = "E"
       }
     }
     assert_equal(4, @rbtree.size)
-    
+
     @rbtree.bound("b", "c") {
       @rbtree.bound("b", "c") {}
       assert_raises(TypeError) {
@@ -643,10 +643,10 @@ class RBTreeTest < Test::Unit::TestCase
     }
     assert_equal(4, @rbtree.size)
   end
-  
+
   def test_first
     assert_equal(["a", "A"], @rbtree.first)
-    
+
     rbtree = RBTree.new("e")
     assert_equal("e", rbtree.first)
 
@@ -656,7 +656,7 @@ class RBTreeTest < Test::Unit::TestCase
 
   def test_last
     assert_equal(["d", "D"], @rbtree.last)
-    
+
     rbtree = RBTree.new("e")
     assert_equal("e", rbtree.last)
 
@@ -666,26 +666,26 @@ class RBTreeTest < Test::Unit::TestCase
 
   def test_readjust
     assert_equal(nil, @rbtree.cmp_proc)
-    
+
     @rbtree.readjust {|a, b| b <=> a }
     assert_equal(%w(d c b a), @rbtree.keys)
     assert_not_equal(nil, @rbtree.cmp_proc)
-    
+
     proc = Proc.new {|a,b| a.to_s <=> b.to_s }
     @rbtree.readjust(proc)
     assert_equal(%w(a b c d), @rbtree.keys)
     assert_equal(proc, @rbtree.cmp_proc)
-    
+
     @rbtree[0] = nil
     assert_raises(ArgumentError) { @rbtree.readjust(nil) }
     assert_equal(5, @rbtree.size)
     assert_equal(proc, @rbtree.cmp_proc)
-    
+
     @rbtree.delete(0)
     @rbtree.readjust(nil)
     assert_raises(ArgumentError) { @rbtree[0] = nil }
-    
-    
+
+
     rbtree = RBTree.new
     key = ["a"]
     rbtree[key] = nil
@@ -703,57 +703,57 @@ class RBTreeTest < Test::Unit::TestCase
     }
     assert_raises(ArgumentError) { @rbtree.readjust(proc, proc) }
   end
-  
+
   def test_replace
     rbtree = RBTree.new { "e" }
     rbtree.readjust {|a, b| a <=> b}
     rbtree["a"] = "A"
     rbtree["e"] = "E"
-    
+
     @rbtree.replace(rbtree)
     assert_equal(%w(a A e E), @rbtree.to_a.flatten)
-    assert_equal(rbtree.default, @rbtree.default)    
+    assert_equal(rbtree.default, @rbtree.default)
     assert_equal(rbtree.cmp_proc, @rbtree.cmp_proc)
 
     assert_raises(TypeError) { @rbtree.replace("e") }
   end
-  
+
   def test_reverse_each
     ret = []
     @rbtree.reverse_each { |key, val| ret.push([key, val]) }
     assert_equal(%w(d D c C b B a A), ret.flatten)
-    
+
     if defined?(Enumerable::Enumerator)
       enumerator = @rbtree.reverse_each
       assert_equal(%w(d D c C b B a A), enumerator.map.flatten)
     end
   end
-  
+
   def test_marshal
     assert_equal(@rbtree, Marshal.load(Marshal.dump(@rbtree)))
-    
+
     @rbtree.default = "e"
     assert_equal(@rbtree, Marshal.load(Marshal.dump(@rbtree)))
-    
+
     assert_raises(TypeError) {
       Marshal.dump(RBTree.new { "e" })
     }
-    
+
     assert_raises(TypeError) {
       @rbtree.readjust {|a, b| a <=> b}
       Marshal.dump(@rbtree)
     }
   end
-  
+
   begin
     require "pp"
-    
+
     def test_pp
       assert_equal(%(#<RBTree: {}, default=nil, cmp_proc=nil>\n),
                    PP.pp(RBTree.new, ""))
       assert_equal(%(#<RBTree: {"a"=>"A", "b"=>"B"}, default=nil, cmp_proc=nil>\n),
                    PP.pp(RBTree[*%w(a A b B)], ""))
-      
+
       rbtree = RBTree[*("a".."z").to_a]
       rbtree.default = "a"
       rbtree.readjust {|a, b| a <=> b }


### PR DESCRIPTION
The Rakefile requires rcov, which doesn't work on Ruby 2.

Hash uses eql? to compare objects. RBTree uses <=> and ==. This change makes it <=> and eql?, and ensures that they are only called on a key, never on the value being searched for.

RBTree#merge! requires another RBTree, even when a Hash would do.This fixes that.

Trailing white-space (left by inferior editors) can upset other inferior editors. This removes it all.
